### PR TITLE
Fixed failing WPF tests in .NET4.5.

### DIFF
--- a/Sample_CUITeTestProject_WpfControls for .NET v4.5 (VS2013)/Sample_CUITeTestProject_WpfControls.csproj
+++ b/Sample_CUITeTestProject_WpfControls for .NET v4.5 (VS2013)/Sample_CUITeTestProject_WpfControls.csproj
@@ -29,7 +29,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET45;VS2013</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;NET45;VS2013</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/Sample_CUITeTestProject_WpfControls/WpfControlTests.cs
+++ b/Sample_CUITeTestProject_WpfControls/WpfControlTests.cs
@@ -26,8 +26,11 @@ namespace Sample_CUITeTestProject_WpfControls
             #if VS2013
                 [DeploymentItem(@"..\..\..\ControlTemplateExamples for .NET v4 (VS2013)\bin\Debug")]
             #endif
-        #else
-            [DeploymentItem(@"..\..\..\ControlTemplateExamples (NET45)\bin\Debug")]
+        #endif
+        #if NET45
+            #if VS2013
+                [DeploymentItem(@"..\..\..\ControlTemplateExamples for .NET v4.5 (VS2013)\bin\x86\Debug")]
+            #endif
         #endif
     #else
         #if NET40
@@ -42,8 +45,11 @@ namespace Sample_CUITeTestProject_WpfControls
             #if VS2013
                 [DeploymentItem(@"..\..\..\ControlTemplateExamples for .NET v4 (VS2013)\bin\Release")]
             #endif
-        #else
-            [DeploymentItem(@"..\..\..\ControlTemplateExamples (NET45)\bin\Release")]
+        #endif
+        #if NET45
+            #if VS2013
+                [DeploymentItem(@"..\..\..\ControlTemplateExamples for .NET v4.5 (VS2013)\bin\x86\Release")]
+            #endif
         #endif
     #endif
     public class WpfControlTests


### PR DESCRIPTION
Fixed failing WPF unit tests in the .NET4.5 VS2013 solution. Related to issue 3.
