### PR TITLE
Updated common assembly information

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -1,11 +1,11 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyDescription("Coded UI Test enhanced Framework (CUITe) http://cuite.codeplex.com")]
+[assembly: AssemblyDescription("Coded UI Test enhanced Framework (CUITe) https://github.com/icnocop/cuite")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyCompany("icnocop")]
 [assembly: AssemblyProduct("CUITe")]
-[assembly: AssemblyCopyright("Copyright © Microsoft 2011 - 2013")]
+[assembly: AssemblyCopyright("Copyright © icnocop 2011 - 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
Made sure that 'icnocop' and not 'Microsoft' is mentioned in the assembly information.

BTW, sorry for the bombardment of small pull requests, but I am in parallel working on my _FantasticFiasco:code-structure-consolidation_ branch and don't want to pollute it with minor details like this one. It would make it harder for you to review the pull request in the end.

Have a nice day, good sir.
