### PR TITLE
Dependency to Microsoft Visual Studio 2013 Coded UI Test Plugin for Silverlight

### DIFF
--- a/src/CUITe.sln
+++ b/src/CUITe.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Local.testsettings = Local.testsettings
 		..\README.md = ..\README.md
 		readme.txt = readme.txt
+		SilverlightExtension.targets = SilverlightExtension.targets
 		TraceAndTestImpact.testsettings = TraceAndTestImpact.testsettings
 	EndProjectSection
 EndProject

--- a/src/CUITe/CUITe.csproj
+++ b/src/CUITe/CUITe.csproj
@@ -81,10 +81,6 @@
           <Private>False</Private>
           <HintPath>..\ThirdParty\CUIT\v10\Microsoft.VisualStudio.TestTools.UITesting.dll</HintPath>
         </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-          <HintPath>..\ThirdParty\CUIT\v10\Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight.dll</HintPath>
-        </Reference>
       </ItemGroup>
     </When>
     <When Condition="'$(VisualStudioVersion)' == '11'">
@@ -97,10 +93,6 @@
           <Private>False</Private>
           <HintPath>..\ThirdParty\CUIT\v11\Microsoft.VisualStudio.TestTools.UITesting.dll</HintPath>
         </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight, Version=11.0.0.0, Culture=neutral, PublicKeyToken=374b4c93160c098c, processorArchitecture=MSIL">
-          <Private>False</Private>
-          <HintPath>..\ThirdParty\CUIT\v11\Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight.dll</HintPath>
-        </Reference>
       </ItemGroup>
     </When>
     <When Condition="'$(VisualStudioVersion)' == '12'">
@@ -110,10 +102,6 @@
         </Reference>
         <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
           <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-          <HintPath>..\ThirdParty\CUIT\v12\Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight.dll</HintPath>
         </Reference>
       </ItemGroup>
     </When>
@@ -295,6 +283,7 @@
     <Compile Include="ObjectRepositoryManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
+  <Import Project="$(SolutionDir)\SilverlightExtension.targets" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Sample_CUITeTestProject/Sample_CUITeTestProject.csproj
+++ b/src/Sample_CUITeTestProject/Sample_CUITeTestProject.csproj
@@ -45,7 +45,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-    <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
@@ -126,6 +125,7 @@
       </ItemGroup>
     </When>
   </Choose>
+  <Import Project="$(SolutionDir)\SilverlightExtension.targets" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/SilverlightExtension.targets
+++ b/src/SilverlightExtension.targets
@@ -1,0 +1,28 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Choose>
+        <When Condition="'$(VisualStudioVersion)' == '10'">
+            <ItemGroup>
+                <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+                    <Private>False</Private>
+                    <HintPath>$(MSBuildThisFileDirectory)ThirdParty\CUIT\v10\Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight.dll</HintPath>
+                </Reference>
+            </ItemGroup>
+        </When>
+        <When Condition="'$(VisualStudioVersion)' == '11'">
+            <ItemGroup>
+                <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight, Version=11.0.0.0, Culture=neutral, PublicKeyToken=374b4c93160c098c, processorArchitecture=MSIL">
+                    <Private>False</Private>
+                    <HintPath>$(MSBuildThisFileDirectory)ThirdParty\CUIT\v11\Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight.dll</HintPath>
+                </Reference>
+            </ItemGroup>
+        </When>
+        <When Condition="'$(VisualStudioVersion)' == '12'">
+            <ItemGroup>
+                <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+                    <Private>False</Private>
+                    <HintPath>$(MSBuildThisFileDirectory)ThirdParty\CUIT\v12\Microsoft.VisualStudio.TestTools.UITest.Extension.Silverlight.dll</HintPath>
+                </Reference>
+            </ItemGroup>
+        </When>
+    </Choose>
+</Project>

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,9 +3,6 @@ Development Environment System Requirements:
 
 Visual Studio 2013 Premium or Ultimate
 
-Microsoft Visual Studio 2013 Coded UI Test Plugin for Silverlight
-https://visualstudiogallery.msdn.microsoft.com/51b4a94a-1878-4dcc-81e0-7dc92131d2da
-
 Selenium components for Coded UI Cross Browser Testing
 https://visualstudiogallery.msdn.microsoft.com/11cfc881-f8c9-4f96-b303-a2780156628d
 


### PR DESCRIPTION
## Description

It is no longer a prerequisite to have [Microsoft Visual Studio 2013 Coded UI Test Plugin for Silverlight](https://visualstudiogallery.msdn.microsoft.com/51b4a94a-1878-4dcc-81e0-7dc92131d2da) installed on the computer. This will hopefully fix the build errors occurring in issue #18.
