### PR TITLE
Fixed CI build

### DIFF
--- a/src/Build.proj
+++ b/src/Build.proj
@@ -3,13 +3,13 @@
 
   <!-- Properties -->
   <PropertyGroup>
-    <CurrentDirectory>$(MSBuildProjectDirectory)</CurrentDirectory>
-    <CvsRootPath>$(CurrentDirectory)\..</CvsRootPath>
-    <SolutionPath>$(CurrentDirectory)\CUITe.sln</SolutionPath>
-    <ProjectDir>$(CurrentDirectory)\CUITe</ProjectDir>
+    <CurrentDirectory>$(MSBuildProjectDirectory)\</CurrentDirectory>
+    <CvsRootPath>$(CurrentDirectory)..</CvsRootPath>
+    <SolutionPath>$(CurrentDirectory)CUITe.sln</SolutionPath>
+    <ProjectDir>$(CurrentDirectory)CUITe</ProjectDir>
     <ProjectPath>$(ProjectDir)\CUITe.csproj</ProjectPath>
     <NuGetSpecPath>$(ProjectDir)\CUITe.nuspec</NuGetSpecPath>
-    <NuGetPath>$(CurrentDirectory)\.nuget\NuGet.exe</NuGetPath>
+    <NuGetPath>$(CurrentDirectory).nuget\NuGet.exe</NuGetPath>
     <VSTestPath>%VSINSTALLDIR%Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe</VSTestPath>
   </PropertyGroup>
 
@@ -69,7 +69,11 @@
 
   <!-- Runs all tests -->
   <Target Name="Test">
-    <Exec Command="&quot;$(VSTestPath)&quot; Sample_CUITeTestProject\bin\Release\Sample_CUITeTestProject.dll Sample_CUITeTestProject_WinControls\bin\Release\Sample_CUITeTestProject_WinControls.dll Sample_CUITeTestProject_WpfControls\bin\Release\Sample_CUITeTestProject_WpfControls.dll" />
+    <ItemGroup>
+      <TestAssemblies Include="$(CurrentDirectory)**\bin\Release\*Test.dll" />
+    </ItemGroup>
+      
+    <Exec Command="&quot;$(VSTestPath)&quot; @(TestAssemblies->'&quot;%(FullPath)&quot;', ' ') Sample_CUITeTestProject\bin\Release\Sample_CUITeTestProject.dll" />
   </Target>
   
 </Project>

--- a/src/CUITe.sln
+++ b/src/CUITe.sln
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{90152298
 		CUITe\CUITe.VS2010.nuspec = CUITe\CUITe.VS2010.nuspec
 		CUITe\CUITe.VS2012.nuspec = CUITe\CUITe.VS2012.nuspec
 		CUITe\CUITe.VS2013.nuspec = CUITe\CUITe.VS2013.nuspec
+		..\Test.bat = ..\Test.bat
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aut.Wpf.Controls", "Aut.Wpf.Controls\Aut.Wpf.Controls.csproj", "{26221FFA-E635-4D86-B7CE-53BB16F0399C}"


### PR DESCRIPTION
## Description

Fixed bug where _Build.proj_ was referencing a test assembly no longer existing.
## Fix

I've modified the build script to search for test assemblies instead of hard-coding the paths. If we follow the naming convention of having the suffix _Test_ on test assemblies they will automatically be picked up by the build script.

With that said, we still have one test assembly that needs some love and that is _Sample_CUITeTestProject_. It is still hard coded in the build script but I am working on changing that in a upcoming PR.
