### PR TITLE
Added Silverlight plugin as a prerequisite again

### DIFF
--- a/src/Build.proj
+++ b/src/Build.proj
@@ -21,6 +21,7 @@
       Properties="Configuration=Release"
       Targets="Rebuild"
       BuildInParallel="true" />
+    
     <!-- VS2013 .NET40 (Silverlight not supported) -->
     <MSBuild
       Projects="$(ProjectPath)"
@@ -34,6 +35,7 @@
       Properties="Configuration=Release;VisualStudioVersion=11;TargetFrameworkVersion=v4.5"
       Targets="Rebuild"
       BuildInParallel="true" />
+    
     <!-- VS2012 .NET40 -->
     <MSBuild
       Projects="$(ProjectPath)"

--- a/src/Sample_CUITeTestProject/HtmlControlTests.cs
+++ b/src/Sample_CUITeTestProject/HtmlControlTests.cs
@@ -57,6 +57,7 @@ namespace Sample_CUITeTestProject
             GoogleHomePage pgGHomePage = BrowserWindowUnderTest.Launch<GoogleHomePage>("http://www.google.com");
             pgGHomePage.txtSearch.SetText("Coded UI Test Framework");
             GoogleSearch pgSearch = BrowserWindowUnderTest.GetBrowserWindow<GoogleSearch>();
+// ReSharper disable once UnusedVariable
             UITestControlCollection col = pgSearch.divSearchResults.UnWrap().GetChildren();
             //do something with collection
             pgSearch.Close();

--- a/src/readme.txt
+++ b/src/readme.txt
@@ -3,6 +3,9 @@ Development Environment System Requirements:
 
 Visual Studio 2013 Premium or Ultimate
 
+Microsoft Visual Studio 2013 Coded UI Test Plugin for Silverlight
+https://visualstudiogallery.msdn.microsoft.com/51b4a94a-1878-4dcc-81e0-7dc92131d2da
+
 Selenium components for Coded UI Cross Browser Testing
 https://visualstudiogallery.msdn.microsoft.com/11cfc881-f8c9-4f96-b303-a2780156628d
 


### PR DESCRIPTION
## Description

Cleaned up my previous PR. Added _Microsoft Visual Studio 2013 Coded UI Test Plugin for Silverlight_ as a mandatory prerequisite again. You can always remove it when the plugin is installed with  initialization scripts.

Lets see what happens with the CI server before merging the PR. If the tests fails due to invalid technology name (Silverlight) I think we can merge it. The tests will then pass when the plugin is installed on the CI server (saw you got a response from the AppVeyor people).
