### PR TITLE
Moved Telerik ComboBox

### DIFF
--- a/src/CUITe/CUITe.csproj
+++ b/src/CUITe/CUITe.csproj
@@ -175,7 +175,7 @@
     <Compile Include="Controls\HtmlControls\HtmlXml.cs" />
     <Compile Include="Controls\HtmlControls\IHasInnerText.cs" />
     <Compile Include="Controls\ModifierKeysLifetime.cs" />
-    <Compile Include="Controls\TelerikControls\ComboBox.cs" />
+    <Compile Include="Controls\HtmlControls\Telerik\ComboBox.cs" />
     <Compile Include="Controls\UIWindowsSecurityWindow.cs" />
     <Compile Include="Controls\WinControls\WinButton.cs" />
     <Compile Include="Controls\WinControls\WinCalendar.cs" />

--- a/src/CUITe/Controls/HtmlControls/BrowserWindowUnderTest.cs
+++ b/src/CUITe/Controls/HtmlControls/BrowserWindowUnderTest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using CUITe.Browsers;
-using CUITe.Controls.TelerikControls;
+using CUITe.Controls.HtmlControls.Telerik;
 using CUITe.SearchConfigurations;
 using Microsoft.VisualStudio.TestTools.UITesting;
 using CUITControls = Microsoft.VisualStudio.TestTools.UITesting.HtmlControls;

--- a/src/CUITe/Controls/HtmlControls/BrowserWindowUnderTest.cs
+++ b/src/CUITe/Controls/HtmlControls/BrowserWindowUnderTest.cs
@@ -205,7 +205,7 @@ namespace CUITe.Controls.HtmlControls
             {
                 control.SourceControl.Container = SilverlightObjectContainer;
             }
-            else if (typeof(T).Namespace.Equals("CUITe.Controls.TelerikControls"))
+            else if (typeof(T).Namespace.Equals(typeof(ComboBox).Namespace))
             {
                 (control as ComboBox).SetWindow(this);
             }

--- a/src/CUITe/Controls/HtmlControls/Telerik/ComboBox.cs
+++ b/src/CUITe/Controls/HtmlControls/Telerik/ComboBox.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Threading;
-using CUITe.Controls.HtmlControls;
 using CUITe.SearchConfigurations;
 using Microsoft.VisualStudio.TestTools.UITesting;
 using CUITControls = Microsoft.VisualStudio.TestTools.UITesting.HtmlControls;
 
-namespace CUITe.Controls.TelerikControls
+namespace CUITe.Controls.HtmlControls.Telerik
 {
     /// <summary>
     /// Represents a Telerik combo box for Web page user interface (UI) testing.

--- a/src/CUITeTest/Controls/ControlBaseFactoryTest.cs
+++ b/src/CUITeTest/Controls/ControlBaseFactoryTest.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using CUITe.Controls;
-using CUITe.Controls.TelerikControls;
+using CUITe.Controls.HtmlControls.Telerik;
 using CUITe.SearchConfigurations;
 using Microsoft.VisualStudio.TestTools.UITesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/src/Sut.HtmlTest/ObjectRepository/DemosOfTeleriksASPNETComboBoxControl.cs
+++ b/src/Sut.HtmlTest/ObjectRepository/DemosOfTeleriksASPNETComboBoxControl.cs
@@ -1,5 +1,5 @@
 ﻿using CUITe.Controls.HtmlControls;
-using CUITe.Controls.TelerikControls;
+using CUITe.Controls.HtmlControls.Telerik;
 using CUITe.SearchConfigurations;
 using Microsoft.VisualStudio.TestTools.UITesting;
 


### PR DESCRIPTION
Moved Telerik ComboBox to a sub-namespace of 'CUITe.Controls.HtmlControls' since it is a HTML control.
