### PR TITLE
I suggest having these changes in the ControlBase class.

### DIFF
--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightButton.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightButton.cs
@@ -35,7 +35,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.DisplayText;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightCalendar.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightCalendar.cs
@@ -37,7 +37,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedDateRange = value;
             }
         }
@@ -49,7 +49,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedDateRangeAsString = value;
             }
         }
@@ -61,7 +61,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectionMode;
             }
         }
@@ -73,12 +73,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedDates;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedDates = value;
             }
         }
@@ -90,12 +90,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedDatesAsString;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedDatesAsString = value;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightCell.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightCell.cs
@@ -35,12 +35,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Checked;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Checked = value;
             }
         }
@@ -52,7 +52,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ColumnHeader;
             }
         }
@@ -64,7 +64,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ColumnIndex;
             }
         }
@@ -76,7 +76,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.RowIndex;
             }
         }
@@ -88,7 +88,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Selected;
             }
         }
@@ -100,12 +100,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Value;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Value = value;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightCheckBox.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightCheckBox.cs
@@ -58,12 +58,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Checked;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Checked = value;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightComboBox.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightComboBox.cs
@@ -36,7 +36,7 @@ namespace CUITe.Controls.SilverlightControls
         /// <param name="item">The item to select.</param>
         public void SelectItem(string item)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             SourceControl.SelectedItem = item;
         }
 
@@ -46,7 +46,7 @@ namespace CUITe.Controls.SilverlightControls
         /// <param name="index">The index of the item to select.</param>
         public void SelectIndex(int index)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             SourceControl.SelectedIndex = index;
         }
 
@@ -57,12 +57,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedItem;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedItem = value;
             }
         }
@@ -74,12 +74,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedIndex;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedIndex = value;
             }
         }
@@ -91,7 +91,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Items.Count;
             }
         }
@@ -104,7 +104,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Items;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightControl.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightControl.cs
@@ -30,7 +30,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.LabeledBy;
             }
         }
@@ -45,7 +45,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 
                 try
                 {
@@ -68,7 +68,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {
@@ -91,7 +91,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {
@@ -114,7 +114,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {
@@ -132,7 +132,7 @@ namespace CUITe.Controls.SilverlightControls
         /// </summary>
         public override IEnumerable<ControlBase> GetChildren()
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             var uicol = new List<ControlBase>();
             foreach (UITestControl uitestcontrol in SourceControl.GetChildren())
             {

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightEdit.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightEdit.cs
@@ -35,12 +35,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Text;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Text = value;
             }
         }
@@ -52,7 +52,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadOnly;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightLabel.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightLabel.cs
@@ -35,7 +35,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Text;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightList.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightList.cs
@@ -38,7 +38,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Items;
             }
         }
@@ -51,12 +51,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedIndices;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedIndices = value;
             }
         }
@@ -68,12 +68,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedItems;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedItems = value;
             }
         }
@@ -85,12 +85,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedItemsAsString;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedItemsAsString = value;
             }
         }
@@ -102,7 +102,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectionMode;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightPassword.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightPassword.cs
@@ -37,7 +37,7 @@ namespace CUITe.Controls.SilverlightControls
             get { return base.Text; }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Password = Playback.EncryptText(value);
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightRadioButton.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightRadioButton.cs
@@ -36,12 +36,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Selected;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Selected = value;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightSpinner.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightSpinner.cs
@@ -37,12 +37,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return TextBox.Text;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 TextBox.Text = value;
             }
         }
@@ -54,7 +54,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return TextBox.ReadOnly;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightTab.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightTab.cs
@@ -35,12 +35,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedIndex;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedIndex = value;
             }
         }
@@ -52,12 +52,12 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedItem;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedItem = value;
             }
         }
@@ -69,7 +69,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Items.Count;
             }
         }

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightTable.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightTable.cs
@@ -36,7 +36,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.RowCount;
             }
         }
@@ -105,7 +105,7 @@ namespace CUITe.Controls.SilverlightControls
             int columnIndex,
             SilverlightTableSearchOptions searchOptions)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
 
             int rowIndex = -1;
             int rowCount = -1;
@@ -177,7 +177,7 @@ namespace CUITe.Controls.SilverlightControls
 
         private CUITControls.SilverlightCell GetCell(int rowIndex, int columnIndex)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             CUITControls.SilverlightCell _SlCell = null;
             int rowCount = -1;
             foreach (CUITControls.SilverlightRow cont in SourceControl.Rows)

--- a/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightText.cs
+++ b/src/CUITe.Silverlight/Controls/SilverlightControls/SilverlightText.cs
@@ -35,7 +35,7 @@ namespace CUITe.Controls.SilverlightControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Text;
             }
         }

--- a/src/CUITe/Controls/ControlBase.cs
+++ b/src/CUITe/Controls/ControlBase.cs
@@ -16,6 +16,7 @@ namespace CUITe.Controls
     public abstract class ControlBase
     {
         private readonly UITestControl sourceControl;
+        private static bool isControlReadinessAwaitedByDefault;
 
         protected static readonly PropertyNamesCache PropertyNamesCache;
 
@@ -47,7 +48,7 @@ namespace CUITe.Controls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return sourceControl.Enabled;
             }
         }
@@ -76,6 +77,15 @@ namespace CUITe.Controls
         public Type SourceControlType
         {
             get { return sourceControl.GetType(); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not the <see cref="WaitForControlReady"/> method is executed each time the control is used.
+        /// </summary>
+        public static bool IsControlReadinessChecked
+        {
+            get { return isControlReadinessAwaitedByDefault; }
+            set { isControlReadinessAwaitedByDefault = value; }
         }
         
         /// <summary>
@@ -124,11 +134,38 @@ namespace CUITe.Controls
         }
 
         /// <summary>
+        /// Waits for the control to be ready.
+        /// </summary>
+        protected void WaitForControlReadyIfNecessary()
+        {
+            if (isControlReadinessAwaitedByDefault)
+            {
+                sourceControl.WaitForControlReady();
+            }
+        }
+
+        /// <summary>
+        /// Waits for the control to appear in the user interface.
+        /// </summary>
+        public void WaitForControlExist()
+        {
+            sourceControl.WaitForControlExist();
+        }
+
+        /// <summary>
+        /// Waits for the control to appear in the user interface, or for the specified timeout to expire.
+        /// </summary>
+        public void WaitForControlExist(int millisecondsTimeout)
+        {
+            sourceControl.WaitForControlExist(millisecondsTimeout);
+        }
+
+        /// <summary>
         /// Waits for the control to be ready and attempts to set focus.
         /// </summary>
         public void SetFocus()
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             sourceControl.SetFocus();
         }
 
@@ -140,7 +177,7 @@ namespace CUITe.Controls
         /// </param>
         public void Click(MouseButtons button = MouseButtons.Left)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             Mouse.Click(sourceControl, button);
         }
 
@@ -153,7 +190,7 @@ namespace CUITe.Controls
         /// </param>
         public void Click(ModifierKeys modifierKeys)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             Mouse.Click(sourceControl, modifierKeys);
         }
 
@@ -165,7 +202,7 @@ namespace CUITe.Controls
         /// </param>
         public void DoubleClick(MouseButtons button = MouseButtons.Left)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             Mouse.DoubleClick(sourceControl, button);
         }
 
@@ -178,7 +215,7 @@ namespace CUITe.Controls
         /// </param>
         public void DoubleClick(ModifierKeys modifierKeys)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             Mouse.DoubleClick(sourceControl, modifierKeys);
         }
 
@@ -194,7 +231,7 @@ namespace CUITe.Controls
         /// </remarks>
         public void PointAndClick()
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             int centerX = sourceControl.BoundingRectangle.X + sourceControl.BoundingRectangle.Width / 2;
             int centerY = sourceControl.BoundingRectangle.Y + sourceControl.BoundingRectangle.Height / 2;
             Mouse.Click(new Point(centerX, centerY));
@@ -213,7 +250,7 @@ namespace CUITe.Controls
         /// </remarks>
         public void PressModifierKeys(ModifierKeys keys)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             Keyboard.PressModifierKeys(sourceControl, keys);
         }
 
@@ -226,7 +263,7 @@ namespace CUITe.Controls
         /// </param>
         public void ReleaseModifierKeys(ModifierKeys keys)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             Keyboard.ReleaseModifierKeys(sourceControl, keys);
         }
 
@@ -246,7 +283,7 @@ namespace CUITe.Controls
         /// </remarks>
         public IDisposable HoldModifierKeys(ModifierKeys keys)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             return new ModifierKeysLifetime(this, keys);
         }
 
@@ -283,7 +320,7 @@ namespace CUITe.Controls
             bool isEncoded = false,
             bool isUnicode = true)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             Keyboard.SendKeys(sourceControl, text, modifierKeys, isEncoded, isUnicode);
         }
     }

--- a/src/CUITe/Controls/ControlBase.cs
+++ b/src/CUITe/Controls/ControlBase.cs
@@ -16,7 +16,6 @@ namespace CUITe.Controls
     public abstract class ControlBase
     {
         private readonly UITestControl sourceControl;
-        private static bool isControlReadinessAwaitedByDefault;
 
         protected static readonly PropertyNamesCache PropertyNamesCache;
 
@@ -82,11 +81,7 @@ namespace CUITe.Controls
         /// <summary>
         /// Gets or sets a value indicating whether or not the <see cref="WaitForControlReady"/> method is executed each time the control is used.
         /// </summary>
-        public static bool IsControlReadinessChecked
-        {
-            get { return isControlReadinessAwaitedByDefault; }
-            set { isControlReadinessAwaitedByDefault = value; }
-        }
+        public static bool IsControlReadinessAwaitedByDefault { get; set; }
         
         /// <summary>
         /// Gets the parent of the control.
@@ -128,9 +123,9 @@ namespace CUITe.Controls
         /// <summary>
         /// Waits for the control to be ready.
         /// </summary>
-        public void WaitForControlReady()
+        public bool WaitForControlReady()
         {
-            sourceControl.WaitForControlReady();
+            return sourceControl.WaitForControlReady();
         }
 
         /// <summary>
@@ -138,7 +133,7 @@ namespace CUITe.Controls
         /// </summary>
         protected void WaitForControlReadyIfNecessary()
         {
-            if (isControlReadinessAwaitedByDefault)
+            if (IsControlReadinessAwaitedByDefault)
             {
                 sourceControl.WaitForControlReady();
             }
@@ -147,17 +142,20 @@ namespace CUITe.Controls
         /// <summary>
         /// Waits for the control to appear in the user interface.
         /// </summary>
-        public void WaitForControlExist()
+        /// <returns><code>true</code> if this control exists before the time-out; otherwise, <code>false</code>.</returns>
+        public bool WaitForControlExist()
         {
-            sourceControl.WaitForControlExist();
+            return sourceControl.WaitForControlExist();
         }
 
         /// <summary>
         /// Waits for the control to appear in the user interface, or for the specified timeout to expire.
         /// </summary>
-        public void WaitForControlExist(int millisecondsTimeout)
+        /// <param name="millisecondsTimeout">The number of milliseconds before time-out.</param>
+        /// <returns><code>true</code> if this control exists before the time-out; otherwise, <code>false</code>.</returns>
+        public bool WaitForControlExist(int millisecondsTimeout)
         {
-            sourceControl.WaitForControlExist(millisecondsTimeout);
+            return sourceControl.WaitForControlExist(millisecondsTimeout);
         }
 
         /// <summary>

--- a/src/CUITe/Controls/HtmlControls/HtmlAreaHyperlink.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlAreaHyperlink.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.AbsolutePath;
             }
         }
@@ -46,7 +46,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Alt;
             }
         }
@@ -58,7 +58,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Href;
             }
         }
@@ -70,7 +70,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Target;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlAudio.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlAudio.cs
@@ -35,7 +35,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.AutoPlay;
             }
         }
@@ -47,7 +47,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentSrc;
             }
         }
@@ -59,7 +59,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentTime;
             }
         }
@@ -71,7 +71,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentTimeAsString;
             }
         }
@@ -83,7 +83,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Duration;
             }
         }
@@ -95,7 +95,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.DurationAsString;
             }
         }
@@ -107,7 +107,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Ended;
             }
         }
@@ -119,7 +119,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Loop;
             }
         }
@@ -131,7 +131,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Muted;
             }
         }
@@ -143,7 +143,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Paused;
             }
         }
@@ -155,7 +155,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.PlaybackRate;
             }
         }
@@ -167,7 +167,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadyState;
             }
         }
@@ -179,7 +179,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Seeking;
             }
         }
@@ -191,7 +191,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Src;
             }
         }
@@ -203,7 +203,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Volume;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlCheckBox.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlCheckBox.cs
@@ -43,7 +43,7 @@ namespace CUITe.Controls.HtmlControls
         /// </summary>
         public void Check2()
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             string sOnClick = (string)SourceControl.GetProperty("onclick");
             string sId = SourceControl.Id;
             if (sId == null || sId == "")
@@ -71,12 +71,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Checked;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Checked = value;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlComboBox.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlComboBox.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         /// <param name="item">The item to select.</param>
         public void SelectItem(string item)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             SourceControl.SelectedItem = item;
         }
 
@@ -44,7 +44,7 @@ namespace CUITe.Controls.HtmlControls
         /// <param name="index">The index of the item to select.</param>
         public void SelectIndex(int index)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             SourceControl.SelectedIndex = index;
         }
 
@@ -55,12 +55,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedItem;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedItem = value;
             }
         }
@@ -72,12 +72,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedIndex;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedIndex = value;
             }
         }
@@ -89,7 +89,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ItemCount;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlControl.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlControl.cs
@@ -31,7 +31,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.InnerText;
             }
         }
@@ -43,7 +43,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.HelpText;
             }
         }
@@ -55,7 +55,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Title;
             }
         }
@@ -67,7 +67,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ValueAttribute;
             }
         }
@@ -79,7 +79,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.AccessKey;
             }
         }
@@ -94,7 +94,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {
@@ -117,7 +117,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {
@@ -140,7 +140,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {
@@ -171,7 +171,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {
@@ -189,7 +189,7 @@ namespace CUITe.Controls.HtmlControls
         /// </summary>
         public override IEnumerable<ControlBase> GetChildren()
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
 
             return SourceControl.GetChildren()
                 .Select(child => WrapUtil((CUITControls.HtmlControl)child))

--- a/src/CUITe/Controls/HtmlControls/HtmlEdit.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlEdit.cs
@@ -34,12 +34,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Text;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Text = value;
             }
         }
@@ -51,7 +51,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadOnly;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlEditableDiv.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlEditableDiv.cs
@@ -34,12 +34,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Text;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Text = value;
             }
         }
@@ -51,7 +51,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadOnly;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlEditableSpan.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlEditableSpan.cs
@@ -34,12 +34,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Text;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Text = value;
             }
         }
@@ -51,7 +51,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadOnly;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlFileInput.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlFileInput.cs
@@ -34,12 +34,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.FileName;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.FileName = value;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlFrame.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlFrame.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.AbsolutePath;
             }
         }
@@ -46,7 +46,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.PageUrl;
             }
         }
@@ -58,7 +58,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Scrollable;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlInputButton.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlInputButton.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.DisplayText;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlLabel.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlLabel.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.LabelFor;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlList.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlList.cs
@@ -50,12 +50,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.SelectedItems;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.SelectedItems = value;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlMedia.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlMedia.cs
@@ -35,7 +35,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.AutoPlay;
             }
         }
@@ -47,7 +47,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentSrc;
             }
         }
@@ -59,7 +59,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentTime;
             }
         }
@@ -71,7 +71,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentTimeAsString;
             }
         }
@@ -83,7 +83,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Duration;
             }
         }
@@ -95,7 +95,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.DurationAsString;
             }
         }
@@ -107,7 +107,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Ended;
             }
         }
@@ -119,7 +119,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Loop;
             }
         }
@@ -131,7 +131,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Muted;
             }
         }
@@ -143,7 +143,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Paused;
             }
         }
@@ -155,7 +155,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.PlaybackRate;
             }
         }
@@ -167,7 +167,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadyState;
             }
         }
@@ -179,7 +179,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Seeking;
             }
         }
@@ -191,7 +191,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Src;
             }
         }
@@ -203,7 +203,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Volume;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlProgressBar.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlProgressBar.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Max;
             }
         }
@@ -46,7 +46,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Value;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlRadioButton.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlRadioButton.cs
@@ -43,7 +43,7 @@ namespace CUITe.Controls.HtmlControls
         /// </summary>
         public void Select2()
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             string sOnClick = (string)SourceControl.GetProperty("onclick");
             string sId = SourceControl.Id;
             if (sId == null || sId == "")
@@ -60,12 +60,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Selected;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Selected = value;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlScrollBar.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlScrollBar.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Orientation;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlSlider.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlSlider.cs
@@ -34,7 +34,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Disabled;
             }
         }
@@ -46,7 +46,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Max;
             }
         }
@@ -58,7 +58,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Min;
             }
         }
@@ -70,7 +70,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Required;
             }
         }
@@ -82,7 +82,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Step;
             }
         }
@@ -94,7 +94,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Value;
             }
         }
@@ -106,7 +106,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ValueAsNumber;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlTable.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlTable.cs
@@ -36,7 +36,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ColumnCount;
             }
         }
@@ -48,7 +48,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Rows.Count;
             }
         }
@@ -130,7 +130,7 @@ namespace CUITe.Controls.HtmlControls
             int columnIndex,
             HtmlTableSearchOptions searchOptions)
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             int iRow = -1;
             int rowCount = -1;
 
@@ -310,7 +310,7 @@ namespace CUITe.Controls.HtmlControls
 
         private T GetCell<T>(int iRow, int iCol) where T : ControlBase, IHasInnerText
         {
-            WaitForControlReady();
+            WaitForControlReadyIfNecessary();
             UITestControl htmlCell = null;
             int rowCount = -1;
 

--- a/src/CUITe/Controls/HtmlControls/HtmlTextArea.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlTextArea.cs
@@ -34,12 +34,12 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Text;
             }
             set
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 SourceControl.Text = value;
             }
         }
@@ -51,7 +51,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadOnly;
             }
         }

--- a/src/CUITe/Controls/HtmlControls/HtmlVideo.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlVideo.cs
@@ -35,7 +35,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.AutoPlay;
             }
         }
@@ -47,7 +47,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentSrc;
             }
         }
@@ -59,7 +59,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentTime;
             }
         }
@@ -71,7 +71,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.CurrentTimeAsString;
             }
         }
@@ -83,7 +83,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Duration;
             }
         }
@@ -95,7 +95,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.DurationAsString;
             }
         }
@@ -107,7 +107,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Ended;
             }
         }
@@ -119,7 +119,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Loop;
             }
         }
@@ -131,7 +131,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Muted;
             }
         }
@@ -143,7 +143,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Paused;
             }
         }
@@ -155,7 +155,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.PlaybackRate;
             }
         }
@@ -167,7 +167,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Poster;
             }
         }
@@ -179,7 +179,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.ReadyState;
             }
         }
@@ -191,7 +191,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Seeking;
             }
         }
@@ -203,7 +203,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Src;
             }
         }
@@ -215,7 +215,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.VideoHeight;
             }
         }
@@ -227,7 +227,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.VideoWidth;
             }
         }
@@ -239,7 +239,7 @@ namespace CUITe.Controls.HtmlControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 return SourceControl.Volume;
             }
         }

--- a/src/CUITe/Controls/WinControls/WinControl.cs
+++ b/src/CUITe/Controls/WinControls/WinControl.cs
@@ -33,7 +33,7 @@ namespace CUITe.Controls.WinControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
 
                 try
                 {

--- a/src/CUITe/Controls/WpfControls/WpfControl.cs
+++ b/src/CUITe/Controls/WpfControls/WpfControl.cs
@@ -33,7 +33,7 @@ namespace CUITe.Controls.WpfControls
         {
             get
             {
-                WaitForControlReady();
+                WaitForControlReadyIfNecessary();
                 
                 try
                 {


### PR DESCRIPTION
I suggest having these changes in the ControlBase class.

The first one, which is about disabling the control readiness check, will allow to increase the tests' execution speed, and the second one just includes an ability to wait for a control to exist in the UI (because WaitForControlReady is definitely not enough).

All meaningful changes are in the ControlBase class. Other classes are affected by renaming the WaitForControlReady method to WaitForControlReadyIfNecessary (it is also made protected).
