### PR TITLE
Issue 92

### DIFF
--- a/src/CUITe/Controls/ControlBaseOfT.cs
+++ b/src/CUITe/Controls/ControlBaseOfT.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using CUITe.SearchConfigurations;
 using Microsoft.VisualStudio.TestTools.UITesting;
 

--- a/src/CUITe/Controls/HtmlControls/HtmlControl.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlControl.cs
@@ -199,19 +199,22 @@ namespace CUITe.Controls.HtmlControls
 
             foreach (ControlBase child in children)
             {
-                int tagInstances;
-                if (tagInstancesByType.ContainsKey(child.GetType()))
+                if (child.SourceControl.SearchProperties.Any())
                 {
-                    tagInstances = tagInstancesByType[child.GetType()] += 1;
+                    int tagInstances;
+                    if (tagInstancesByType.ContainsKey(child.GetType()))
+                    {
+                        tagInstances = tagInstancesByType[child.GetType()] += 1;
+                    }
+                    else
+                    {
+                        tagInstances = tagInstancesByType[child.GetType()] = 1;
+                    }
+
+                    child.SourceControl.FilterProperties.Add(
+                        CUITControls.HtmlControl.PropertyNames.TagInstance,
+                        tagInstances.ToString());    
                 }
-                else
-                {
-                    tagInstances = tagInstancesByType[child.GetType()] = 1;
-                }
-                
-                child.SourceControl.FilterProperties.Add(
-                    CUITControls.HtmlControl.PropertyNames.TagInstance,
-                    tagInstances.ToString());
 
                 yield return child;
             }

--- a/src/CUITe/Controls/HtmlControls/HtmlControl.cs
+++ b/src/CUITe/Controls/HtmlControls/HtmlControl.cs
@@ -191,9 +191,30 @@ namespace CUITe.Controls.HtmlControls
         {
             WaitForControlReadyIfNecessary();
 
-            return SourceControl.GetChildren()
+            ControlBase[] children = SourceControl.GetChildren()
                 .Select(child => WrapUtil((CUITControls.HtmlControl)child))
                 .ToArray();
+
+            Dictionary<Type, int> tagInstancesByType = new Dictionary<Type, int>();
+
+            foreach (ControlBase child in children)
+            {
+                int tagInstances;
+                if (tagInstancesByType.ContainsKey(child.GetType()))
+                {
+                    tagInstances = tagInstancesByType[child.GetType()] += 1;
+                }
+                else
+                {
+                    tagInstances = tagInstancesByType[child.GetType()] = 1;
+                }
+                
+                child.SourceControl.FilterProperties.Add(
+                    CUITControls.HtmlControl.PropertyNames.TagInstance,
+                    tagInstances.ToString());
+
+                yield return child;
+            }
         }
 
         /// <summary>

--- a/src/SystemsUnderTest/Sut.HtmlTest/HtmlControlTests.cs
+++ b/src/SystemsUnderTest/Sut.HtmlTest/HtmlControlTests.cs
@@ -1401,5 +1401,91 @@ namespace Sut.HtmlTest
                 browserWindow.Close();
             }
         }
+
+        /// <summary>
+        /// https://github.com/icnocop/cuite/issues/92
+        /// </summary>
+        [TestMethod]
+        public void GetChildrenOfSameType()
+        {
+            // Arrange
+            using (var webPage = new TempWebPage(
+                @"<html>
+                    <head>
+                        <title>test</title>
+                    </head>
+                    <body>
+                        <div id=""panel"">
+                            <p>1</p>
+                            <p>2</p>
+                            <p>3</p>
+                        </div>
+                    </body>
+                </html>"))
+            {
+                var browserWindow = BrowserWindow.Launch(webPage.FilePath);
+                var panel = browserWindow.Find<HtmlDiv>(By.Id("panel"));
+
+                // Act
+                ControlBase[] children = panel.GetChildren().ToArray();
+
+                // Assert
+                Assert.AreEqual(3, children.Length);
+                
+                Assert.IsInstanceOfType(children[0], typeof(HtmlParagraph));
+                Assert.AreEqual("1", ((HtmlParagraph)children[0]).InnerText);
+
+                Assert.IsInstanceOfType(children[1], typeof(HtmlParagraph));
+                Assert.AreEqual("2", ((HtmlParagraph)children[1]).InnerText);
+
+                Assert.IsInstanceOfType(children[2], typeof(HtmlParagraph));
+                Assert.AreEqual("3", ((HtmlParagraph)children[2]).InnerText);
+                
+                browserWindow.Close();
+            }
+        }
+
+        /// <summary>
+        /// https://github.com/icnocop/cuite/issues/92
+        /// </summary>
+        [TestMethod]
+        public void GetChildrenOfMixedType()
+        {
+            // Arrange
+            using (var webPage = new TempWebPage(
+                @"<html>
+                    <head>
+                        <title>test</title>
+                    </head>
+                    <body>
+                        <div id=""panel"">
+                            <p>1</p>
+                            <h1>2</h1>
+                            <p>3</p>
+                        </div>
+                    </body>
+                </html>"))
+            {
+                var browserWindow = BrowserWindow.Launch(webPage.FilePath);
+                var panel = browserWindow.Find<HtmlDiv>(By.Id("panel"));
+
+                // Act
+                ControlBase[] children = panel.GetChildren().ToArray();
+
+                // Assert
+                Assert.AreEqual(3, children.Length);
+
+                Assert.IsInstanceOfType(children[0], typeof(HtmlParagraph));
+                Assert.AreEqual("1", ((HtmlParagraph)children[0]).InnerText);
+
+                Assert.IsInstanceOfType(children[1], typeof(HtmlHeading1));
+                Assert.AreEqual("2", ((HtmlHeading1)children[1]).InnerText);
+
+                Assert.IsInstanceOfType(children[2], typeof(HtmlParagraph));
+                Assert.AreEqual("3", ((HtmlParagraph)children[2]).InnerText);
+
+                browserWindow.Close();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix issue where children returned from a HtmlControl doesn't match the actual children in the DOM. Adding search properties (which is what happens when CUITe wraps the CUIT control) seems to re-evaluate the found element, and instead of returning the correct control instead always returns the first child.
