### PR TITLE
Fixes issue #87 and #89

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 2.0 (TBD)
 =========
 
+* Fixed [#89](https://github.com/icnocop/cuite/issues/89) - [@FantasticFiasco](https://github.com/FantasticFiasco)
+* Fixed [#87](https://github.com/icnocop/cuite/issues/87) - [@FantasticFiasco](https://github.com/FantasticFiasco)
 * Fixed [#92](https://github.com/icnocop/cuite/issues/92) - [@FantasticFiasco](https://github.com/FantasticFiasco)
 * Fixed [#83](https://github.com/icnocop/cuite/issues/83) - [@aannenko](https://github.com/aannenko)
 * Removed validation of search property names to support custom arbitrary search property names [#77](https://github.com/icnocop/cuite/issues/77)

--- a/src/CUITe.IntegrationTests/NuGet/NuGetFeatureSteps.cs
+++ b/src/CUITe.IntegrationTests/NuGet/NuGetFeatureSteps.cs
@@ -9,13 +9,11 @@
     using System.Runtime.InteropServices;
     using System.Text.RegularExpressions;
     using System.Threading;
-    using System.Windows.Forms;
     using System.Xml;
     using System.Xml.Serialization;
     using EnvDTE;
     using EnvDTE80;
     using Microsoft.VisualStudio;
-    using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Win32;
     using TechTalk.SpecFlow;

--- a/src/CUITe.sln.DotSettings
+++ b/src/CUITe.sln.DotSettings
@@ -151,6 +151,7 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=Jasmine/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/DisabledProviders/=QUnit/@EntryIndexedValue">True</s:Boolean>
 	

--- a/src/CUITe/PageObjects/ViewObject.cs
+++ b/src/CUITe/PageObjects/ViewObject.cs
@@ -13,6 +13,22 @@ namespace CUITe.PageObjects
         private UITestControl searchLimitContainer;
 
         /// <summary>
+        /// Highlights the control.
+        /// </summary>
+        public void DrawHighlight()
+        {
+            searchLimitContainer.DrawHighlight();
+        }
+
+        /// <summary>
+        /// Gets the control object represented by the view object.
+        /// </summary>
+        public ControlBase Self
+        {
+            get { return ControlBaseFactory.Create(searchLimitContainer); }
+        }
+
+        /// <summary>
         /// Gets or sets the search limit container.
         /// </summary>
         internal virtual UITestControl SearchLimitContainer

--- a/src/CUITe/ScreenObjects/ScreenObject.cs
+++ b/src/CUITe/ScreenObjects/ScreenObject.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using CUITe.PageObjects;
 using Microsoft.VisualStudio.TestTools.UITesting;
+using CUITWinWindow = Microsoft.VisualStudio.TestTools.UITesting.WinControls.WinWindow;
+using CUITWpfWindow = Microsoft.VisualStudio.TestTools.UITesting.WpfControls.WpfWindow;
 
 namespace CUITe.ScreenObjects
 {
@@ -55,13 +57,36 @@ namespace CUITe.ScreenObjects
         /// Navigates to a new screen.
         /// </summary>
         /// <typeparam name="T">The type of screen to navigate to.</typeparam>
+        /// <param name="title">The title of the screen.</param>
         /// <returns>The new screen.</returns>
-        protected T NavigateTo<T>() where T : Screen, new()
+        protected T NavigateTo<T>(string title) where T : Screen, new()
         {
+            if (title == null)
+                throw new ArgumentNullException("title");
+
+            UITestControl searchLimitContainer;
+            
+            switch (Application.TechnologyName)
+            {
+                case "MSAA":
+                    searchLimitContainer = new CUITWinWindow();
+                    break;
+
+                case "UIA":
+                    searchLimitContainer = new CUITWpfWindow();
+                    break;
+
+                default:
+                    throw new NotSupportedException(string.Format("Technology {0} is not supported.", Application.TechnologyName));
+            }
+
+            searchLimitContainer.SearchProperties[UITestControl.PropertyNames.Name] = title;
+            searchLimitContainer.WindowTitles.Add(title);
+
             return new T
             {
                 Application = Application,
-                SearchLimitContainer = Application
+                SearchLimitContainer = searchLimitContainer
             };
         }
     }

--- a/src/CUITe/ScreenObjects/ScreenObjectOfT.cs
+++ b/src/CUITe/ScreenObjects/ScreenObjectOfT.cs
@@ -38,15 +38,6 @@ namespace CUITe.ScreenObjects
         }
 
         /// <summary>
-        /// Gets the rebased control specified by the search configuration in
-        /// <see cref="ScreenObject{T}(By)"/>.
-        /// </summary>
-        public UITestControl Self
-        {
-            get { return SearchLimitContainer; }
-        }
-
-        /// <summary>
         /// Gets or sets the search limit container.
         /// </summary>
         internal override UITestControl SearchLimitContainer

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/Dialog.Designer.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/Dialog.Designer.cs
@@ -62,7 +62,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "Dialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "System Under Test (WinForms)";
+            this.Text = "Dialog";
             this.ResumeLayout(false);
 
         }

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/IdenticalButtonContentDialog.Designer.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/IdenticalButtonContentDialog.Designer.cs
@@ -1,0 +1,74 @@
+﻿namespace Sut.WinForms.ScreenObjects
+{
+    partial class IdenticalButtonContentDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(IdenticalButtonContentDialog));
+            this.buttonIdenticalContent = new System.Windows.Forms.Button();
+            this.labelDescription = new System.Windows.Forms.Label();
+            this.SuspendLayout();
+            // 
+            // buttonIdenticalContent
+            // 
+            this.buttonIdenticalContent.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.buttonIdenticalContent.Location = new System.Drawing.Point(12, 42);
+            this.buttonIdenticalContent.Name = "buttonIdenticalContent";
+            this.buttonIdenticalContent.Size = new System.Drawing.Size(189, 23);
+            this.buttonIdenticalContent.TabIndex = 7;
+            this.buttonIdenticalContent.Text = "Identical Button Content";
+            this.buttonIdenticalContent.UseVisualStyleBackColor = true;
+            // 
+            // labelDescription
+            // 
+            this.labelDescription.Location = new System.Drawing.Point(12, 9);
+            this.labelDescription.Name = "labelDescription";
+            this.labelDescription.Size = new System.Drawing.Size(189, 30);
+            this.labelDescription.TabIndex = 8;
+            this.labelDescription.Text = "Button has identical content as the button in the parent window.";
+            // 
+            // IdenticalButtonContentDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(213, 77);
+            this.Controls.Add(this.labelDescription);
+            this.Controls.Add(this.buttonIdenticalContent);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.Name = "IdenticalButtonContentDialog";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Identical Button Content Dialog";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Button buttonIdenticalContent;
+        private System.Windows.Forms.Label labelDescription;
+    }
+}

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/IdenticalButtonContentDialog.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/IdenticalButtonContentDialog.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows.Forms;
+
+namespace Sut.WinForms.ScreenObjects
+{
+    public partial class IdenticalButtonContentDialog : Form
+    {
+        public IdenticalButtonContentDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/IdenticalButtonContentDialog.resx
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/IdenticalButtonContentDialog.resx
@@ -1,0 +1,216 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        AAABAAIAICAAAAEAIACoEAAAJgAAABAQAAABACAAaAQAAM4QAAAoAAAAIAAAAEAAAAABACAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAO+vPxDipDaH4aQ20eKkNujipDbc4qU3tOCkNnbiojgkAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADvrz8Q4aQ22OKlN//hpTe34KM1Q9+fNyDiqDks46Y3XOGl
+        N6XhpDa14aU4Tf//AAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOKkNofipTf/4aU3waqqVQMAAAAAAAAAAAAA
+        AAAAAAAAAAAAAN+fLxDgpDd34aQ2teGjNj0AAAAAAAAAAH9/AAL//wABAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4qQ31OKlN//ipjZZAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAOapPBXhpTdy4aU29+GkNtvipTby4qU3/+GlN/3hpDfr4aU3x+Gk
+        NpLjpjZL1KoqBgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADipTfx4qU3/9+l
+        NTkAAAAAAAAAAAAAAAAAAAAAAAAAAOCjNirhpDem4qU3+uKlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTbp4qQ2f9qjNg4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOKk
+        N+vipTf/5Kc5QwAAAAAAAAAAAAAAANqRJAfhpTeL4aQ2++KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU359+kN1IAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAA4qU3y+KlN//ipjhtAAAAAAAAAADdpjcX4aQ2yeKlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+OlN4t/fwACAAAAAAAA
+        AAAAAAAAAAAAAAAAAADipDaW4qU3/+GkN68AAAAA3KI5FuKkNtfipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Gj
+        NpoAAAAAAAAAAAAAAAAAAAAAAAAAAOGmN07ipTf/4aQ29uShNRPipDbD4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlNnUAAAAAAAAAAAAAAAAAAAAA2rZIB+KkNu7ipTf/4qU30OKlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4qU3/+KlNuDhpTdy4ac2PeGmN0XhpTeL4aU39OKlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4aU3+uKkOC0AAAAAAAAAAAAAAAAAAAAA4KQ3j+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//hpTfB2qM2DgAAAAAAAAAAAAAAAAAAAADmpzcp4aQ26OKl
+        N//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3uQAAAAAAAAAAAAAAAAAAAADnpzcH4qU3A+Kl
+        NwLipTcFEQwEGg0JAxHipTcB4qU3BeKlNwPipTcF4qU2AgAAAAAAAAAYAAAAEAAAAAAAAAAAAAAAAAAA
+        AADhpDYC4qU3B+KlNwHipTcB4qU3AeKlNwLipTcC4qU3AeKlNwHipTcB4qQ4AQAAAAAAAAAAAAAAAAAA
+        AAAAAAAEAAAAlwAAANMAAACPAAAAbAAAAIMAAAAwAAAAAAAAAAAAAAA0AAAA5wAAAL8AAAB0AAAAfAAA
+        ACgAAAAAAAAAGAAAAIcAAAD/AAAAwwAAADAAAAAAAAAACAAAAEwAAAD/AAAA/wAAAEwAAAAIAAAAAAAA
+        AAAAAAAAAAAAAAAAAKsAAAD/AAAATOKlNwHipTcBAAAAAAAAAGAAAAAAAAAAAAAAAMsAAAD/AAAABAAA
+        AAAAAAAAAAAAiwAAAAAAAAAAAAAAQAAAAP8AAACfAAAAAAAAAAAAAAAAAAAAAAAAAP8AAAD/AAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAkAAAA/wEAANPipTcC4qU3AeKlNwHipTcDAAAAAOKlNwHipTcBAQEA9wMC
+        APPhpDYE4aQ2AuGkNgEBAQB94aQ2AuGkNgIKBwJCAgEA/wEBAJ8AAAAAAAAAAAAAAAAAAAAAAAAA/wAA
+        AP8AAAAA4aU2AQAAAAAAAAAAAAAAAAAAAGgAAAD/AAAAswAAAAAAAAAAAAAAAOKlNwHipTcBAAAAAAAA
+        AAAAAAD/AAAA3+KlNwXipTcH4qU3AQEBAIDipTcB4qU3AQAAAEAAAAD/AQEAn+KlNwHipTcBAAAAAAAA
+        AAAAAAD/AAAA/wAAAADipTcCAAAAAAAAAAAAAAAAAgIATQAAAP8AAACzAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAA4qU3BwYEAf8FAwHg4qU3AwAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAQAAAAP8BAQCf4qU3AeKl
+        NwEAAAAAAAAAAAAAAP8AAAD/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIAAAA9wAAAOsAAAAAAAAAAOKl
+        NwEAAAAAAAAAQAAAAAAAAAAAAAAA/wAAAN8AAAAAAAAAAAAAAAAAAACAAAAAAAAAAAAAAABAAAAA/wAA
+        AJ8AAAAAAAAAGAAAAAAAAAAAAAAA/wAAAP8AAAAAAAAAAAAAABQAAAAAAAAAAAAAAAAAAABUAAAA+wAA
+        AGAAAAAA4KQ2AbyJLRgbFAbb4qU3GeKlNwgCAQD/AAAA7+GlNAHhpTQB4aU0AQEBAIAAAAAQAAAAAAAA
+        AEAAAAD/AAAAn+KlNwEBAQCXAAAAEAAAAAAAAAD/AAAA/wAAAAAAAAAEAAAAgwAAAAAAAAAAAAAAAAAA
+        AAAAAABUAAAAwwAAAKsAAACDAAAAnwAAALcAAAAAAAAAcAAAAP8AAAD/AAAAaAAAAAAAAAA8AAAAxwAA
+        AIcAAAAkAAAAnwAAAP8AAADPAAAAQAAAAJ8AAADXAAAAjwAAAP8AAAD/AAAAjwAAAMMAAACfAAAAAAAA
+        AAAAAAAA4aQ1B+KlNwTipTcHQjAQEQAAAATiqTgCcFIbEOKlNw7ipTcO4qU3E+KmOAMAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAADhozUB4qU3A+KlNwPipTcE4qU3BOKlNwfipTcE4qU3BeKlNwXhpTcDAAAAAAAA
+        AAAAAAAAAAAAAAAAAADiqTgJ4aU25OKlN//hpTf+46Q3dwAAAADgozYq4aQ36+KlN//ipTf/4qQ38OGl
+        OE0AAAAAAAAAAAAAAAD/vz8E4qQ3fOGkN/7ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Gk
+        NpsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADhpjhW4qU3/+KlN//ipTf/4aU3nN+fPwjfpjQx4aU27eKl
+        N//ipTf/4qU3/+GlN9Djpjab4aQ2o+GkNuTipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipDfr5605FgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADhpDab4qU3/+KlN//ipTf/4qQ20eGl
+        NzPkpDUw4aQ26uKlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4aQ2/OOlN0oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP+ZMwXipTew4qU3/+Kl
+        N//ipTf/4aQ2/OOlN5zjpTdK4qQ23+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+GlN/3ipThkAAAAAAAAAAAAAAAA4ac6IwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP+/
+        PwTipDaW4qU3/+KlN//ipTf/4qU3/+GlN/3ipDfU4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//hpDbz46U3UwAAAAAAAAAAAAAAAAAAAADipTaIAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAADiozVR4aQ34uKlN//ipTf/4qU3/+KlN//ipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//ipTf/4KQ2u+KiOCQAAAAAAAAAAAAAAAAAAAAAAAAAAOGlN5QAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADiqTgJ4qQ2a+KkN9TipTf/4qU3/+KlN//ipTf/4qU3/+Kl
+        N//ipTf/4qU3/+KlN//hpDb74qU3tOGlOEQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4aU2rQAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOCjNiripTdq4aU2muGl
+        N7fipTfF4qU3wuGlN8ripTf/4qU3/+KlN+fhpDVo2pEkBwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOGl
+        NCLhpDbAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAOOkN1LhpDbb4qU3/+KlN//ipDfn4qU3huGlNzP/fwACAAAAAAAA
+        AADfoTcp4aU3z+OlN3gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMyZMwXhpDdg4aU20uKlN//ipTf/4qU3/+Gk
+        NvPipDbW4qU23+KlN/7hpTbS1KoqDAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4aY1NOKk
+        N4XipDfC4aQ26OKlN/HhpDbX4qU2iN2qMw8AAAAAAAAAAIB///8AD///D4Z//x/AA/8fAAD/HAAAfxgA
+        AB8QAAAfAAAADwAAAAeAA8AHgAngA8BgQQPBY2PPgIADy45gAMuPw2DPjWdizcQAIEngQgABwAfgB8ED
+        gAfgAAAH8AAAD/AAAB34AAA9/gAAff8AAf3/4AH5///AMf//4AH///wDKAAAABAAAAAgAAAAAQAgAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAOm/FQzuuh2K7rodme+7HXLwuxw1AAAAAOm/FQzsuR1G7LweY+26
+        H1rtvR0rAAAAAAAAAAAAAAAAAAAAAAAAAADtuh6G7rseqf+qAAP//wAB7bocR+67Hcfuux707rse/+67
+        Hv/uux7/7rse/+26HtHtuhxHAAAAAAAAAAAAAAAA7bods+27HmYAAAAA67odGu66HdXuux7/7rse/+67
+        Hv/uux7/7rse/+67Hv/uux7/7boe/u67HXkAAAAAAAAAAO26HaTuux2L/8wzBe67Hsvuux7/7rse/+67
+        Hv/uuh337rodxe67Hc3tux797rse/+67Hv/uux7/7bocWQAAAADtuh507bod3e66Hmzuux7/7rse/+67
+        Hv/tuh2/87whFwAAAAAAAAAA7r0gL+26HeDuux7/7rse/+66HejlshkK6bYdBO67HgHuuh4BLyUGBQ4L
+        ARHtux4BAAAAAAAAABQAAAAAAAAAAAAAAADvvx8CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOAAA
+        AIsAAAAwAAAAIAAAAFQAAACHAAAASAAAABQAAADHAAAANAAAAAwAAADnAAAAFAAAAAAAAAAAAAAAAAAA
+        AKsAAAA8AAAAAAAAAAAAAACbAAAARAAAACAAAAAgAAAAvwAAACAAAAAAAAAA3wAAAAAAAAAAAAAAAAAA
+        AAAAAAB0AAAATAAAAAAAAAAgAAAAnwAAAEQAAAAgAAAAIAAAAL8AAAAgAAAAFAAAAN8AAAAEAAAADAAA
+        AAAAAAAAAAAAAAAAAEgAAAA4AAAAMAAAAFwAAAA8AAAAJAAAACwAAABoAAAAJAAAAFgAAAB0AAAATAAA
+        ABAAAAAAAAAAAO25HALtuh4B7bsdB+67HgTuuh0BAAAAAAAAAAAAAAAAAAAAAO26HgHuux4BAAAAAAAA
+        AAAAAAAAAAAAAAAAAADovCEX7rsd5u67HZvuux3w7rse/+27Hbzvux517bodgu26Hd3uux7/7rse/+67
+        Hv/tuh2+/rkXCwAAAAAAAAAAAAAAAPC7HkTtuh337boe8+67Hv/uux7/7rse/+67Hv/uux7/7rse/+67
+        Hv/tuh29778fEO29H0oAAAAAAAAAAAAAAAAAAAAA7LkbN+67Hdbuux7/7rse/+67Hv/uux7/7rse/+66
+        HvvvvB2R378fCP//AAHtuh5kAAAAAAAAAAAAAAAAAAAAAAAAAAD/qgAD7rseTO26HZHtuh2u7bsd1u67
+        Hv/uuh3G7LkcUe64Gy/uux2L77wfQQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP//
+        AAHtux8577odg+26Hq/uux6n7LseUwAAAAAEH6xBAAesQSADrEEAAaxBAMCsQQLvrEHAAaxBzAusQcgA
+        rEHgAKxBweesQcAArEHgAKxB8ACsQfgArEH/gaxB
+</value>
+  </data>
+</root>

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/MainForm.Designer.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/MainForm.Designer.cs
@@ -39,10 +39,13 @@
             this.groupBoxLowerRight = new System.Windows.Forms.GroupBox();
             this.buttonOpenModalDialog = new System.Windows.Forms.Button();
             this.buttonOpenNonModalDialog = new System.Windows.Forms.Button();
+            this.buttonIdenticalContent = new System.Windows.Forms.Button();
+            this.groupBoxMiddle = new System.Windows.Forms.GroupBox();
             this.groupBoxUpperLeft.SuspendLayout();
             this.groupBoxUpperRight.SuspendLayout();
             this.groupBoxLowerLeft.SuspendLayout();
             this.groupBoxLowerRight.SuspendLayout();
+            this.groupBoxMiddle.SuspendLayout();
             this.SuspendLayout();
             // 
             // checkBoxUpperLeft
@@ -92,7 +95,7 @@
             this.groupBoxUpperLeft.Controls.Add(this.checkBoxUpperLeft);
             this.groupBoxUpperLeft.Location = new System.Drawing.Point(12, 12);
             this.groupBoxUpperLeft.Name = "groupBoxUpperLeft";
-            this.groupBoxUpperLeft.Size = new System.Drawing.Size(134, 50);
+            this.groupBoxUpperLeft.Size = new System.Drawing.Size(140, 50);
             this.groupBoxUpperLeft.TabIndex = 2;
             this.groupBoxUpperLeft.TabStop = false;
             this.groupBoxUpperLeft.Text = "Upper Left Group";
@@ -100,9 +103,9 @@
             // groupBoxUpperRight
             // 
             this.groupBoxUpperRight.Controls.Add(this.checkBoxUpperRight);
-            this.groupBoxUpperRight.Location = new System.Drawing.Point(152, 12);
+            this.groupBoxUpperRight.Location = new System.Drawing.Point(158, 12);
             this.groupBoxUpperRight.Name = "groupBoxUpperRight";
-            this.groupBoxUpperRight.Size = new System.Drawing.Size(134, 50);
+            this.groupBoxUpperRight.Size = new System.Drawing.Size(140, 50);
             this.groupBoxUpperRight.TabIndex = 3;
             this.groupBoxUpperRight.TabStop = false;
             this.groupBoxUpperRight.Text = "Upper Right Group";
@@ -110,9 +113,9 @@
             // groupBoxLowerLeft
             // 
             this.groupBoxLowerLeft.Controls.Add(this.radioButtonLowerLeft);
-            this.groupBoxLowerLeft.Location = new System.Drawing.Point(12, 97);
+            this.groupBoxLowerLeft.Location = new System.Drawing.Point(12, 151);
             this.groupBoxLowerLeft.Name = "groupBoxLowerLeft";
-            this.groupBoxLowerLeft.Size = new System.Drawing.Size(134, 50);
+            this.groupBoxLowerLeft.Size = new System.Drawing.Size(140, 50);
             this.groupBoxLowerLeft.TabIndex = 3;
             this.groupBoxLowerLeft.TabStop = false;
             this.groupBoxLowerLeft.Text = "Lower Left Group";
@@ -120,16 +123,16 @@
             // groupBoxLowerRight
             // 
             this.groupBoxLowerRight.Controls.Add(this.radioButtonLowerRight);
-            this.groupBoxLowerRight.Location = new System.Drawing.Point(152, 97);
+            this.groupBoxLowerRight.Location = new System.Drawing.Point(158, 151);
             this.groupBoxLowerRight.Name = "groupBoxLowerRight";
-            this.groupBoxLowerRight.Size = new System.Drawing.Size(134, 50);
+            this.groupBoxLowerRight.Size = new System.Drawing.Size(140, 50);
             this.groupBoxLowerRight.TabIndex = 4;
             this.groupBoxLowerRight.TabStop = false;
             this.groupBoxLowerRight.Text = "Lower Right Group";
             // 
             // buttonOpenModalDialog
             // 
-            this.buttonOpenModalDialog.Location = new System.Drawing.Point(12, 68);
+            this.buttonOpenModalDialog.Location = new System.Drawing.Point(6, 19);
             this.buttonOpenModalDialog.Name = "buttonOpenModalDialog";
             this.buttonOpenModalDialog.Size = new System.Drawing.Size(134, 23);
             this.buttonOpenModalDialog.TabIndex = 5;
@@ -139,7 +142,7 @@
             // 
             // buttonOpenNonModalDialog
             // 
-            this.buttonOpenNonModalDialog.Location = new System.Drawing.Point(152, 68);
+            this.buttonOpenNonModalDialog.Location = new System.Drawing.Point(146, 19);
             this.buttonOpenNonModalDialog.Name = "buttonOpenNonModalDialog";
             this.buttonOpenNonModalDialog.Size = new System.Drawing.Size(134, 23);
             this.buttonOpenNonModalDialog.TabIndex = 5;
@@ -147,19 +150,41 @@
             this.buttonOpenNonModalDialog.UseVisualStyleBackColor = true;
             this.buttonOpenNonModalDialog.Click += new System.EventHandler(this.buttonOpenNonModalDialog_Click);
             // 
+            // buttonIdenticalContent
+            // 
+            this.buttonIdenticalContent.Location = new System.Drawing.Point(6, 48);
+            this.buttonIdenticalContent.Name = "buttonIdenticalContent";
+            this.buttonIdenticalContent.Size = new System.Drawing.Size(274, 23);
+            this.buttonIdenticalContent.TabIndex = 6;
+            this.buttonIdenticalContent.Text = "Identical Button Content";
+            this.buttonIdenticalContent.UseVisualStyleBackColor = true;
+            this.buttonIdenticalContent.Click += new System.EventHandler(this.buttonIdenticalContent_Click);
+            // 
+            // groupBoxMiddle
+            // 
+            this.groupBoxMiddle.Controls.Add(this.buttonIdenticalContent);
+            this.groupBoxMiddle.Controls.Add(this.buttonOpenModalDialog);
+            this.groupBoxMiddle.Controls.Add(this.buttonOpenNonModalDialog);
+            this.groupBoxMiddle.Location = new System.Drawing.Point(12, 68);
+            this.groupBoxMiddle.Name = "groupBoxMiddle";
+            this.groupBoxMiddle.Size = new System.Drawing.Size(286, 77);
+            this.groupBoxMiddle.TabIndex = 4;
+            this.groupBoxMiddle.TabStop = false;
+            this.groupBoxMiddle.Text = "Middle Group";
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(298, 159);
-            this.Controls.Add(this.buttonOpenNonModalDialog);
-            this.Controls.Add(this.buttonOpenModalDialog);
+            this.ClientSize = new System.Drawing.Size(310, 213);
+            this.Controls.Add(this.groupBoxMiddle);
             this.Controls.Add(this.groupBoxLowerRight);
             this.Controls.Add(this.groupBoxLowerLeft);
             this.Controls.Add(this.groupBoxUpperRight);
             this.Controls.Add(this.groupBoxUpperLeft);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "MainForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "System Under Test (WinForms)";
             this.groupBoxUpperLeft.ResumeLayout(false);
             this.groupBoxUpperLeft.PerformLayout();
@@ -169,6 +194,7 @@
             this.groupBoxLowerLeft.PerformLayout();
             this.groupBoxLowerRight.ResumeLayout(false);
             this.groupBoxLowerRight.PerformLayout();
+            this.groupBoxMiddle.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -185,6 +211,8 @@
         private System.Windows.Forms.GroupBox groupBoxLowerRight;
         private System.Windows.Forms.Button buttonOpenModalDialog;
         private System.Windows.Forms.Button buttonOpenNonModalDialog;
+        private System.Windows.Forms.Button buttonIdenticalContent;
+        private System.Windows.Forms.GroupBox groupBoxMiddle;
     }
 }
 

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/MainForm.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/MainForm.cs
@@ -18,5 +18,10 @@ namespace Sut.WinForms.ScreenObjects
         {
             new Dialog().Show(this);
         }
+
+        private void buttonIdenticalContent_Click(object sender, System.EventArgs e)
+        {
+            new IdenticalButtonContentDialog().ShowDialog(this);
+        }
     }
 }

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/Sut.WinForms.ScreenObjects.csproj
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjects/Sut.WinForms.ScreenObjects.csproj
@@ -58,6 +58,12 @@
     <Compile Include="Dialog.Designer.cs">
       <DependentUpon>Dialog.cs</DependentUpon>
     </Compile>
+    <Compile Include="IdenticalButtonContentDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="IdenticalButtonContentDialog.Designer.cs">
+      <DependentUpon>IdenticalButtonContentDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -76,6 +82,9 @@
   <ItemGroup>
     <EmbeddedResource Include="Dialog.resx">
       <DependentUpon>Dialog.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="IdenticalButtonContentDialog.resx">
+      <DependentUpon>IdenticalButtonContentDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/ScreenObjects/IdenticalButtonContentScreen.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/ScreenObjects/IdenticalButtonContentScreen.cs
@@ -1,0 +1,14 @@
+﻿using CUITe.Controls.WinControls;
+using CUITe.ScreenObjects;
+using CUITe.SearchConfigurations;
+
+namespace Sut.WinForms.ScreenObjectsTest.ScreenObjects
+{
+    public class IdenticalButtonContentScreen : Screen
+    {
+        public void ClickIdenticalButton()
+        {
+            Find<WinButton>(By.Name("Identical Button Content")).Click();
+        }
+    }
+}

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/ScreenObjects/MiddleScreenObject.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/ScreenObjects/MiddleScreenObject.cs
@@ -8,14 +8,20 @@ namespace Sut.WinForms.ScreenObjectsTest.ScreenObjects
     {
         public DialogScreen NavigateToModalDialogScreen()
         {
-            Find<WinButton>(By.ControlName("buttonOpenModalDialog")).Click();
-            return NavigateTo<DialogScreen>();
+            Find<WinButton>(By.Name("Open Modal Dialog")).Click();
+            return NavigateTo<DialogScreen>("Dialog");
         }
 
         public DialogScreen NavigateToNonModalDialogScreen()
         {
-            Find<WinButton>(By.ControlName("buttonOpenNonModalDialog")).Click();
-            return NavigateTo<DialogScreen>();
+            Find<WinButton>(By.Name("Open Non-Modal Dialog")).Click();
+            return NavigateTo<DialogScreen>("Dialog");
+        }
+
+        public IdenticalButtonContentScreen NavigateToIdenticalButtonContentScreen()
+        {
+            Find<WinButton>(By.Name("Identical Button Content")).Click();
+            return NavigateTo<IdenticalButtonContentScreen>("Identical Button Content Dialog");
         }
     }
 }

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/ScreenObjectsTest.cs
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/ScreenObjectsTest.cs
@@ -134,5 +134,18 @@ namespace Sut.WinForms.ScreenObjectsTest
             // Assert
             Assert.IsTrue(dialogScreen.CloseButtonExists);
         }
+
+        [TestMethod]
+        public void ButtonInDialogWithIdenticalContent()
+        {
+            // Arrange
+            var identicalButtonContentScreen = mainScreen.MiddleScreenObject.NavigateToIdenticalButtonContentScreen();
+
+            // Act
+            identicalButtonContentScreen.ClickIdenticalButton();
+
+            // Assert
+            Assert.IsFalse(identicalButtonContentScreen.Self.Exists);
+        }
     }
 }

--- a/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/Sut.WinForms.ScreenObjectsTest.csproj
+++ b/src/SystemsUnderTest/Sut.WinForms.ScreenObjectsTest/Sut.WinForms.ScreenObjectsTest.csproj
@@ -57,6 +57,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ScreenObjects\DialogScreen.cs" />
+    <Compile Include="ScreenObjects\IdenticalButtonContentScreen.cs" />
     <Compile Include="ScreenObjects\LowerLeftScreenObject.cs" />
     <Compile Include="ScreenObjects\LowerRightScreenObject.cs" />
     <Compile Include="ScreenObjects\MainScreen.cs" />

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/Dialog.xaml
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/Dialog.xaml
@@ -2,7 +2,7 @@
     x:Class="Sut.Wpf.ScreenObjects.Dialog"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    Title="System Under Test (WPF)"
+    Title="Dialog"
     Icon="App.ico"
     WindowStartupLocation="CenterOwner"
     SizeToContent="WidthAndHeight">

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/IdenticalButtonContentDialog.xaml
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/IdenticalButtonContentDialog.xaml
@@ -1,0 +1,20 @@
+﻿<Window
+    x:Class="Sut.Wpf.ScreenObjects.IdenticalButtonContentDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="Identical Button Content Dialog"
+    Icon="App.ico"
+    WindowStartupLocation="CenterOwner"
+    Width="200"
+    SizeToContent="Height">
+    
+    <StackPanel>
+        <TextBlock
+            AutomationProperties.AutomationId="fumKtarA_UGA-ODl3itsiA"
+            Text="Button has identical content as the button in the parent window."
+            TextWrapping="Wrap" />
+        <Button
+            Content="Identical Button Content"
+            IsCancel="True" />
+    </StackPanel>
+</Window>

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/IdenticalButtonContentDialog.xaml.cs
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/IdenticalButtonContentDialog.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Sut.Wpf.ScreenObjects
+{
+    public partial class IdenticalButtonContentDialog
+    {
+        public IdenticalButtonContentDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/MainWindow.xaml
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/MainWindow.xaml
@@ -51,20 +51,42 @@
                 AutomationProperties.AutomationId="C_-kLEiiN0Odz20KncjQJQ"
                 Content="Upper right control" />
         </GroupBox>
-
-        <!-- Open dialog buttons -->
-        <Button
+        
+        <!-- Middle control -->
+        <GroupBox
             Grid.Row="1"
-            AutomationProperties.AutomationId="wimAM1xvJkqKO5jO9uUrSg"
-            Content="Open Modal Dialog"
-            Click="OnOpenModalDialog_Click"/>
-        <Button
-            Grid.Row="1"
-            Grid.Column="1"
-            AutomationProperties.AutomationId="i_mSaEucbU-ohslSj7y9aA"
-            Content="Open Non-Modal Dialog"
-            Click="OnOpenNonModalDialog"/>
+            Grid.ColumnSpan="2"
+            Header="Middle Group">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
 
+                <!-- Open dialog buttons -->
+                <Button
+                    AutomationProperties.AutomationId="wimAM1xvJkqKO5jO9uUrSg"
+                    Content="Open Modal Dialog"
+                    Click="OnOpenModalDialog_Click"/>
+                <Button
+                    Grid.Column="1"
+                    AutomationProperties.AutomationId="i_mSaEucbU-ohslSj7y9aA"
+                    Content="Open Non-Modal Dialog"
+                    Click="OnOpenNonModalDialog"/>
+
+                <!-- Open dialog with a button identical to this -->
+                <Button
+                    Grid.Row="1"
+                    Grid.ColumnSpan="2"
+                    Content="Identical Button Content"
+                    Click="OnOpenIdenticalButtonContentDialog"/>
+            </Grid>
+        </GroupBox>
+        
         <!-- Lower left control -->
         <GroupBox
             Grid.Row="2"

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/MainWindow.xaml.cs
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/MainWindow.xaml.cs
@@ -28,5 +28,15 @@ namespace Sut.Wpf.ScreenObjects
 
             dialog.Show();
         }
+
+        private void OnOpenIdenticalButtonContentDialog(object sender, RoutedEventArgs e)
+        {
+            var dialog = new IdenticalButtonContentDialog
+            {
+                Owner = this
+            };
+
+            dialog.ShowDialog();
+        }
     }
 }

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/Sut.Wpf.ScreenObjects.csproj
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjects/Sut.Wpf.ScreenObjects.csproj
@@ -62,6 +62,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="IdenticalButtonContentDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -75,6 +79,9 @@
     </Compile>
     <Compile Include="Dialog.xaml.cs">
       <DependentUpon>Dialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="IdenticalButtonContentDialog.xaml.cs">
+      <DependentUpon>IdenticalButtonContentDialog.xaml</DependentUpon>
     </Compile>
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/ScreenComponentsTest.cs
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/ScreenComponentsTest.cs
@@ -134,5 +134,18 @@ namespace Sut.Wpf.ScreenObjectsTest
             // Assert
             Assert.IsTrue(dialogScreen.CloseButtonExists);
         }
+
+        [TestMethod]
+        public void ButtonInDialogWithIdenticalContent()
+        {
+            // Arrange
+            var identicalButtonContentScreen = mainScreen.MiddleScreenObject.NavigateToIdenticalButtonContentScreen();
+            
+            // Act
+            identicalButtonContentScreen.ClickIdenticalButton();
+
+            // Assert
+            Assert.IsFalse(identicalButtonContentScreen.Self.Exists);
+        }
     }
 }

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/ScreenObjects/IdenticalButtonContentScreen.cs
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/ScreenObjects/IdenticalButtonContentScreen.cs
@@ -1,0 +1,14 @@
+﻿using CUITe.Controls.WpfControls;
+using CUITe.ScreenObjects;
+using CUITe.SearchConfigurations;
+
+namespace Sut.Wpf.ScreenObjectsTest.ScreenObjects
+{
+    public class IdenticalButtonContentScreen : Screen
+    {
+        public void ClickIdenticalButton()
+        {
+            Find<WpfButton>(By.Name("Identical Button Content")).Click();
+        }
+    }
+}

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/ScreenObjects/MiddleScreenObject.cs
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/ScreenObjects/MiddleScreenObject.cs
@@ -9,13 +9,19 @@ namespace Sut.Wpf.ScreenObjectsTest.ScreenObjects
         public DialogScreen NavigateToModalDialogScreen()
         {
             Find<WpfButton>(By.AutomationId("wimAM1xvJkqKO5jO9uUrSg")).Click();
-            return NavigateTo<DialogScreen>();
+            return NavigateTo<DialogScreen>("Dialog");
         }
 
         public DialogScreen NavigateToNonModalDialogScreen()
         {
             Find<WpfButton>(By.AutomationId("i_mSaEucbU-ohslSj7y9aA")).Click();
-            return NavigateTo<DialogScreen>();
+            return NavigateTo<DialogScreen>("Dialog");
+        }
+
+        public IdenticalButtonContentScreen NavigateToIdenticalButtonContentScreen()
+        {
+            Find<WpfButton>(By.Name("Identical Button Content")).Click();
+            return NavigateTo<IdenticalButtonContentScreen>("Identical Button Content Dialog");
         }
     }
 }

--- a/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/Sut.Wpf.ScreenObjectsTest.csproj
+++ b/src/SystemsUnderTest/Sut.Wpf.ScreenObjectsTest/Sut.Wpf.ScreenObjectsTest.csproj
@@ -57,6 +57,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ScreenObjects\DialogScreen.cs" />
+    <Compile Include="ScreenObjects\IdenticalButtonContentScreen.cs" />
     <Compile Include="ScreenObjects\LowerLeftScreenObject.cs" />
     <Compile Include="ScreenObjects\LowerRightScreenObject.cs" />
     <Compile Include="ScreenObjects\MainScreen.cs" />


### PR DESCRIPTION
This PR aims at fixing #87 and #89.

It is now mandatory to specify a dialog title when using the `NavigateTo<T>` method, since the search scope will be limited to the new dialog. This will fix the issue we had where a control was found in the main window, and not in the opened dialog.

I've added tests that verify this fix, and also added a `DrawHighlight` method as you requested.
